### PR TITLE
prevent someone unwhitelisting the escrow

### DIFF
--- a/src/escrow/increasing/Lock.sol
+++ b/src/escrow/increasing/Lock.sol
@@ -70,6 +70,7 @@ contract Lock is ILock, ERC721Enumerable, UUPSUpgradeable, DaoAuthorizable {
 
     /// @notice Transfers disabled by default, only whitelisted addresses can receive transfers
     function setWhitelisted(address _account, bool _isWhitelisted) external auth(LOCK_ADMIN_ROLE) {
+        if (_account == escrow) revert ForbiddenWhitelistAddress();
         whitelisted[_account] = _isWhitelisted;
         emit WhitelistSet(_account, _isWhitelisted);
     }

--- a/src/escrow/increasing/interfaces/ILock.sol
+++ b/src/escrow/increasing/interfaces/ILock.sol
@@ -10,6 +10,7 @@ interface IWhitelistEvents {
 
 interface IWhitelistErrors {
     error NotWhitelisted();
+    error ForbiddenWhitelistAddress();
 }
 
 interface IWhitelist is IWhitelistEvents, IWhitelistErrors {

--- a/test/escrow/escrow/EscrowAdmin.t.sol
+++ b/test/escrow/escrow/EscrowAdmin.t.sol
@@ -146,4 +146,11 @@ contract TestEscrowAdmin is EscrowBase {
         vm.expectRevert(err);
         nftLock.upgradeTo(newImpl);
     }
+
+    // hal-16 should not be possible to unwhitelist the escrow
+    function testUnwhitelistEscrow() public {
+        address escrowAddr = nftLock.escrow();
+        vm.expectRevert(ForbiddenWhitelistAddress.selector);
+        nftLock.setWhitelisted(escrowAddr, false);
+    }
 }


### PR DESCRIPTION
This is mistakenly attributed to hal-16 when it refers to hal-15