### PR TITLE
fixed a failing test case due to contract bounding

### DIFF
--- a/test/escrow/escrow/EscrowWithdraw.t.sol
+++ b/test/escrow/escrow/EscrowWithdraw.t.sol
@@ -32,7 +32,12 @@ contract TestWithdraw is EscrowBase, IEscrowCurveUserStorage, IGaugeVote {
 
     // setup a fee withdrawal
     function testFuzz_feeWithdrawal(uint64 _fee, uint128 _dep, address _who) public {
-        vm.assume(_who != address(0) && _who != address(queue) && _who != address(escrow));
+        vm.assume(
+            _who != address(0) &&
+                _who != address(queue) &&
+                _who != address(escrow) &&
+                _who != address(this)
+        );
         vm.assume(_dep > 0);
 
         if (_fee > 1e18) _fee = 1e18;


### PR DESCRIPTION
Some tests in PRs fail due to easy test fixes: our approach to this is:

- Address fixes here in a clear-to-see manner
- PR audit findings against this so we can see clear diff

