### PR TITLE
replaced the warmup with a timestamp

### DIFF
--- a/src/escrow/increasing/interfaces/IEscrowCurveIncreasing.sol
+++ b/src/escrow/increasing/interfaces/IEscrowCurveIncreasing.sol
@@ -34,13 +34,15 @@ interface IEscrowCurveGlobal is IEscrowCurveGlobalStorage {
 interface IEscrowCurveUserStorage {
     /// @notice Captures the shape of the user's voting curve at a specific point in time
     /// @param bias The y intercept of the user's voting curve at the given time
-    /// @param ts The timestamp at which the user's voting curve was captured
+    /// @param checkpointTs The checkpoint when the user voting curve is/was/will be updated
+    /// @param writtenTs The timestamp at which we locked the checkpoint
     /// @param coefficients The coefficients of the curve, supports up to cubic curves.
     /// @dev Coefficients are stored in the following order: [constant, linear, quadratic, cubic]
     /// and not all coefficients are used for all curves.
     struct UserPoint {
         uint256 bias;
-        uint256 ts;
+        uint128 checkpointTs;
+        uint128 writtenTs;
         int256[4] coefficients;
     }
 }

--- a/test/escrow/curve/QuadraticCurveMath.t.sol
+++ b/test/escrow/curve/QuadraticCurveMath.t.sol
@@ -94,7 +94,8 @@ contract TestQuadraticIncreasingCurve is QuadraticCurveBase {
         // check the user point is registered
         IEscrowCurve.UserPoint memory userPoint = curve.userPointHistory(tokenIdFirst, 1);
         assertEq(userPoint.bias, depositFirst, "Bias is incorrect");
-        assertEq(userPoint.ts, block.timestamp, "Timestamp is incorrect");
+        assertEq(userPoint.checkpointTs, block.timestamp, "CP Timestamp is incorrect");
+        assertEq(userPoint.writtenTs, block.timestamp, "Written Timestamp is incorrect");
 
         // balance now is zero but Warm up
         assertEq(curve.votingPowerAt(tokenIdFirst, 0), 0, "Balance after deposit before warmup");

--- a/test/escrow/escrow/EscrowCreateLock.t.sol
+++ b/test/escrow/escrow/EscrowCreateLock.t.sol
@@ -43,8 +43,8 @@ contract TestCreateLock is EscrowBase, IEscrowCurveUserStorage {
     /// @param _value is positive, we check this in a previous test. It needs to fit inside an int256
     /// so we use the maximum value for a uint128
     /// @param _depositor is not the zero address, we check this in a previous test
-    /// @param _time is bound to 128 bits to avoid overflow - seems reasonable as is not a user input
-    function testFuzz_createLock(uint128 _value, address _depositor, uint128 _time) public {
+    /// @param _time is bound to 120 bits to avoid overflow - seems reasonable as is not a user input
+    function testFuzz_createLock(uint128 _value, address _depositor, uint120 _time) public {
         vm.assume(_value > 0);
         vm.assume(_depositor != address(0));
 
@@ -117,7 +117,7 @@ contract TestCreateLock is EscrowBase, IEscrowCurveUserStorage {
             uint256 epoch = curve.userPointEpoch(tokenId);
             UserPoint memory checkpoint = curve.userPointHistory(tokenId, epoch);
             assertEq(checkpoint.bias, _value);
-            assertEq(checkpoint.ts, expectedTime);
+            assertEq(checkpoint.checkpointTs, expectedTime);
         }
     }
 

--- a/test/escrow/escrow/EscrowWithdraw.t.sol
+++ b/test/escrow/escrow/EscrowWithdraw.t.sol
@@ -155,7 +155,8 @@ contract TestWithdraw is EscrowBase, IEscrowCurveUserStorage, IGaugeVote {
         // but we should have written a user point in the future
         UserPoint memory up = curve.userPointHistory(tokenId, 2);
         assertEq(up.bias, 0);
-        assertEq(up.ts, 3 weeks);
+        assertEq(up.writtenTs, block.timestamp);
+        assertEq(up.checkpointTs, 3 weeks);
 
         // should have a ticket expiring in a few days
         assertEq(queue.canExit(tokenId), false);


### PR DESCRIPTION
Replaces the warmup mapping with a checkpoint ts. This adds treaceability and saves gas by writing the timestamps to a single storage slot. 

To address hal-12 we could also add a burndown period, this is not added yet. However with this change, adding a burndown at a later stage when total voting power is added will be trivial.