### PR TITLE
pushed a check to ensure we can't exit if still warming up

### DIFF
--- a/src/escrow/increasing/VotingEscrowIncreasing.sol
+++ b/src/escrow/increasing/VotingEscrowIncreasing.sol
@@ -285,6 +285,10 @@ contract VotingEscrow is
     function beginWithdrawal(uint256 _tokenId) public nonReentrant whenNotPaused {
         // can't exit if you have votes pending
         if (isVoting(_tokenId)) revert CannotExit();
+
+        // in the event of an increasing curve, 0 voting power means voting isn't active
+        if (votingPower(_tokenId) == 0) revert CannotExit();
+
         address owner = IERC721EMB(lockNFT).ownerOf(_tokenId);
 
         // we can remove the user's voting power as it's no longer locked


### PR DESCRIPTION
We don't yet restrict the long warmup period but we do want to prevent cases where someone exits before the warmup. This adds a condition that voting power must be >0 in the escrow before an exit can be queued.