### PR TITLE
remove weak inequalities where possible

### DIFF
--- a/src/clock/Clock.sol
+++ b/src/clock/Clock.sol
@@ -194,9 +194,8 @@ contract Clock is IClock, DaoAuthorizable, UUPSUpgradeable {
         unchecked {
             uint256 elapsed = resolveElapsedInEpoch(timestamp);
             // elapsed > deposit interval, then subtract the interval
-            if (elapsed > CHECKPOINT_INTERVAL) elapsed -= CHECKPOINT_INTERVAL;
-            if (elapsed == 0) return 0;
-            else return CHECKPOINT_INTERVAL - elapsed;
+            if (elapsed >= CHECKPOINT_INTERVAL) elapsed -= CHECKPOINT_INTERVAL;
+            return CHECKPOINT_INTERVAL - elapsed;
         }
     }
 

--- a/src/escrow/increasing/ExitQueue.sol
+++ b/src/escrow/increasing/ExitQueue.sol
@@ -159,7 +159,7 @@ contract ExitQueue is IExitQueue, IClockUser, DaoAuthorizable, UUPSUpgradeable {
         uint cooldownExpiry = block.timestamp + cooldown;
 
         // if the next cp is after the cooldown, return the next cp
-        return nextCP >= cooldownExpiry ? nextCP : cooldownExpiry;
+        return nextCP > cooldownExpiry ? nextCP : cooldownExpiry;
     }
 
     /// @notice Exits the queue for that tokenID.
@@ -192,7 +192,7 @@ contract ExitQueue is IExitQueue, IClockUser, DaoAuthorizable, UUPSUpgradeable {
     function canExit(uint256 _tokenId) public view returns (bool) {
         Ticket memory ticket = _queue[_tokenId];
         if (ticket.holder == address(0)) return false;
-        return block.timestamp >= ticket.exitDate;
+        return block.timestamp > ticket.exitDate;
     }
 
     /// @return holder of a ticket for a given tokenId

--- a/src/escrow/increasing/QuadraticIncreasingEscrow.sol
+++ b/src/escrow/increasing/QuadraticIncreasingEscrow.sol
@@ -197,7 +197,7 @@ contract QuadraticIncreasingEscrow is
     }
 
     function _isWarm(uint256 _tokenId, uint256 _userEpoch, uint256 t) public view returns (bool) {
-        return t >= _userPointWarmup[_tokenId][_userEpoch];
+        return t > _userPointWarmup[_tokenId][_userEpoch];
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/escrow/curve/QuadraticCurveMath.t.sol
+++ b/test/escrow/curve/QuadraticCurveMath.t.sol
@@ -101,7 +101,7 @@ contract TestQuadraticIncreasingCurve is QuadraticCurveBase {
         assertEq(curve.isWarm(tokenIdFirst), false, "Not warming up");
 
         // wait for warmup
-        vm.warp(block.timestamp + curve.warmupPeriod() - 1);
+        vm.warp(block.timestamp + curve.warmupPeriod());
         assertEq(curve.votingPowerAt(tokenIdFirst, 0), 0, "Balance after deposit before warmup");
         assertEq(curve.isWarm(tokenIdFirst), false, "Not warming up");
         assertEq(curve.isWarm(tokenIdSecond), false, "Not warming up II");
@@ -109,21 +109,20 @@ contract TestQuadraticIncreasingCurve is QuadraticCurveBase {
         // warmup complete
         vm.warp(block.timestamp + 1);
 
-        // excel:               449.206158900000000000
-        // solmate:             449.206133622001394300
-        // solmate (optimized): 449.06723257244469756
+        // python:              449.206279554928541696
+        // solmate (optimized): 449.206254284606635132
         assertEq(
             curve.votingPowerAt(tokenIdFirst, block.timestamp),
-            449206133622001394300,
+            449206254284606635132,
             "Balance incorrect after warmup"
         );
         assertEq(curve.isWarm(tokenIdFirst), true, "Still warming up");
 
-        // excel:     1_067_784_257_000000000000000000
-        // solmate:   1_067_784_196_491481599990798396
+        // python:    1067784543380942056100724736
+        // solmate:   1067784483312193384992025326
         assertEq(
             curve.votingPowerAt(tokenIdSecond, block.timestamp),
-            1067784196491481599990798396,
+            1067784483312193384992025326,
             "Balance incorrect after warmup II"
         );
 

--- a/test/escrow/escrow/EscrowCreateLock.t.sol
+++ b/test/escrow/escrow/EscrowCreateLock.t.sol
@@ -22,8 +22,7 @@ contract TestCreateLock is EscrowBase, IEscrowCurveUserStorage {
     }
 
     function _expTime(uint256 _time) internal pure returns (uint256) {
-        if (_time % 1 weeks == 0) return _time;
-        else return uint(_time) + 1 weeks - (_time % 1 weeks);
+        return uint(_time) + 1 weeks - (_time % 1 weeks);
     }
 
     function testCannotCreateLockWithZeroValue() public {
@@ -252,11 +251,11 @@ contract TestCreateLock is EscrowBase, IEscrowCurveUserStorage {
             expectedNextDeposit,
             "shane's lock should snap to the upcoming deposit date"
         );
-        // matt  is an edge case, they should also snap to the nearest deposit date (+0 seconds)
+        // matt  is an edge case, they should also snap to the next deposit date (+1 week)
         assertEq(
             escrow.locked(2).start,
-            expectedNextDeposit,
-            "matt's lock should snap to the upcoming deposit date"
+            expectedNextDeposit + clock.checkpointInterval(),
+            "matt's lock should snap to the next deposit date"
         );
         // phil should snap to the next deposit date (+1 week)
         assertEq(

--- a/test/python/crosscheck.py
+++ b/test/python/crosscheck.py
@@ -4,7 +4,7 @@ DAY =  24 * HOUR
 WEEK = 7 * DAY
 
 # Variables
-AMOUNT = 1000  # example amount to deposit
+AMOUNT = 1_000_000_000  # example amount to deposit
 PERIOD_LENGTH = 2 * WEEK  # example period length in seconds (1 week)
 WARMUP_PERIOD = 3 * DAY  # warmup period in days
 MAX_PERIODS = 5  # maximum periods

--- a/test/voting/GaugeTime.t.sol
+++ b/test/voting/GaugeTime.t.sol
@@ -42,7 +42,7 @@ contract TestGaugeTime is GaugeVotingBase {
             assertEq(voter.epochVoteStart(), block.timestamp + 1 hours);
             assertEq(voter.epochVoteEnd(), block.timestamp + 1 weeks - 1 hours);
             assertEq(voter.votingActive(), false);
-            assertEq(nextDeposit(), block.timestamp);
+            assertEq(nextDeposit(), block.timestamp + 1 weeks);
             assertEq(clock.epochStartsIn(), 0);
 
             // +1hr: voting starts
@@ -78,7 +78,7 @@ contract TestGaugeTime is GaugeVotingBase {
             assertEq(voter.epochVoteStart(), block.timestamp + 1 weeks + 1 hours);
             assertEq(voter.epochVoteEnd(), block.timestamp);
             assertEq(voter.votingActive(), false);
-            assertEq(nextDeposit(), block.timestamp);
+            assertEq(nextDeposit(), block.timestamp + 1 weeks);
             assertEq(clock.epochStartsIn(), 1 weeks);
 
             // whole of next week calculates correctly

--- a/test/voting/GaugeVote.t.sol
+++ b/test/voting/GaugeVote.t.sol
@@ -30,11 +30,19 @@ contract TestGaugeVote is GaugeVotingBase {
     uint256 tokenId;
     address gauge = address(0x420);
 
+    uint time;
+
+    function _increaseTime(uint _by) internal {
+        time += _by;
+        vm.warp(time);
+    }
+
     function setUp() public override {
         super.setUp();
 
         // reset clock
         vm.warp(0);
+        time = block.timestamp;
 
         // means we have voting power
         curve.setWarmupPeriod(0);
@@ -48,8 +56,9 @@ contract TestGaugeVote is GaugeVotingBase {
         }
         vm.stopPrank();
 
-        // warp to an active window
-        vm.warp(1 hours);
+        // activate cp & warp to an active window
+        _increaseTime(2 weeks + 1 hours + 1);
+
         assertGt(escrow.votingPower(tokenId), 0);
         assertTrue(voter.votingActive(), "voting should be active");
 


### PR DESCRIPTION
Replace weak inequalities with strong ones all over the codebase - this is designed to prevent certain classes of timing attack