### PR TITLE
Audit/fixes

### DIFF
--- a/src/delegation/EscrowIVotesAdapter.sol
+++ b/src/delegation/EscrowIVotesAdapter.sol
@@ -439,7 +439,7 @@ contract EscrowIVotesAdapter is
 
         // If the timestamp of last stored token point is the same as
         // current timestamp, overwrite it, otherwise store a new one.
-        if(
+        if (
             latestPointIndex_ != 0 && 
             pointHistory[_delegatee][latestPointIndex_].writtenTs == block.timestamp
         ) {

--- a/src/delegation/EscrowIVotesAdapter.sol
+++ b/src/delegation/EscrowIVotesAdapter.sol
@@ -437,8 +437,17 @@ contract EscrowIVotesAdapter is
         if (lastPoint.slope < 0) lastPoint.slope = 0;
         if (lastPoint.bias < 0) lastPoint.bias = 0;
 
-        latestPointIndex[_delegatee] = ++latestPointIndex_;
-        pointHistory[_delegatee][latestPointIndex_] = lastPoint;
+        // If the timestamp of last stored token point is the same as
+        // current timestamp, overwrite it, otherwise store a new one.
+        if(
+            latestPointIndex_ != 0 && 
+            pointHistory[_delegatee][latestPointIndex_].writtenTs == block.timestamp
+        ) {
+            pointHistory[_delegatee][latestPointIndex_] = lastPoint;
+        } else {
+            latestPointIndex[_delegatee] = ++latestPointIndex_;
+            pointHistory[_delegatee][latestPointIndex_] = lastPoint;
+        }
     }
 
     /// @notice Proxies a call to the ERC721 contract

--- a/src/delegation/EscrowIVotesAdapter.sol
+++ b/src/delegation/EscrowIVotesAdapter.sol
@@ -226,12 +226,14 @@ contract EscrowIVotesAdapter is
     ) internal virtual {
         (int256 totalBias, int256 totalSlope) = (0, 0);
 
+        address lockNFT = IVotingEscrow(escrow).lockNFT();
+
         for (uint256 i = 0; i < _tokenIds.length; i++) {
             uint256 tokenId = _tokenIds[i];
 
             if (_validate) {
-                if (!IVotingEscrow(escrow).isApprovedOrOwner(_sender, tokenId)) {
-                    revert NotApprovedOrOwner();
+                if (IERC721EMB(lockNFT).ownerOf(tokenId) != _sender) {
+                    revert NotOwner();
                 }
 
                 if (tokenIsDelegated(tokenId)) {
@@ -276,13 +278,15 @@ contract EscrowIVotesAdapter is
         bool _validate
     ) internal virtual {
         (int256 totalBias, int256 totalSlope) = (0, 0);
+        
+        address lockNFT = IVotingEscrow(escrow).lockNFT();
 
         for (uint256 i = 0; i < _tokenIds.length; i++) {
             uint256 tokenId = _tokenIds[i];
 
             if (_validate) {
-                if (!IVotingEscrow(escrow).isApprovedOrOwner(_sender, tokenId)) {
-                    revert NotApprovedOrOwner();
+                if (IERC721EMB(lockNFT).ownerOf(tokenId) != _sender) {
+                    revert NotOwner();
                 }
 
                 if (!tokenIsDelegated(tokenId)) {

--- a/src/delegation/IEscrowIVotesAdapter.sol
+++ b/src/delegation/IEscrowIVotesAdapter.sol
@@ -16,7 +16,7 @@ interface IEscrowIVotesAdapterErrorsAndEvents {
 
     error DelegateBySigNotSupported();
 
-    error NotApprovedOrOwner();
+    error NotOwner();
     error InvalidTokenId();
     error DelegationNotAllowed();
     error DelegateeNotSet();

--- a/test/v1_2_0/integration/merge/delegate-approve-base.sol
+++ b/test/v1_2_0/integration/merge/delegate-approve-base.sol
@@ -1,0 +1,221 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+abstract contract TestMerge_ApproveDelegateBase is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 amount1 = 15e18;
+    uint256 amount2 = 20e18;
+    uint256 totalAmount;
+
+    uint256 checkpointTs;
+    uint256 writtenTs;
+
+    function setUp() public virtual override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        totalAmount = amount1 + amount2;
+
+        vm.warp(1);
+        token.transfer(alice, totalAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+
+        // Alice creates 2 locks in the same block (same start time for merge compatibility)
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), totalAmount);
+            escrow.createLock(amount1); // tokenId 1
+            escrow.createLock(amount2); // tokenId 2
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+        writtenTs = block.timestamp;
+    }
+
+    function _warpPastMaturation() internal {
+        uint256 lockEnd = getEndTimestamp(checkpointTs, writtenTs);
+        vm.warp(lockEnd + 1 seconds);
+    }
+
+    function _approveCharlieAndMerge(uint256 _from, uint256 _to) internal {
+        vm.prank(alice);
+        nftLock.setApprovalForAll(charlie, true);
+
+        vm.prank(charlie);
+        escrow.merge(_from, _to);
+    }
+
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal virtual;
+
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Warp past maturation so locks can merge (different effective amounts but same start)
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (undelegated) into token 2 (delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Bob votes on a gauge with his delegated power.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Bob's gauge vote must remain unchanged after merge.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty_WithVote() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Bob votes on a gauge with his delegated voting power
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 bobVoteAtGauge = voter.votes(bob, gauge);
+        assertEq(bobVoteAtGauge, ivotesAdapter.getVotes(bob));
+
+        // Both locks have the same start time, so merge is allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, block.timestamp - checkpointTs));
+
+        // Bob's gauge vote unchanged from when he voted (pre-merge, only amount2 delegated)
+        assertEq(voter.votes(bob, gauge), bobVoteAtGauge);
+
+        // Bob revotes to use his increased voting power from the merge
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        // Bob's gauge vote now reflects the combined amount
+        assertEq(voter.votes(bob, gauge), bias(totalAmount, block.timestamp - checkpointTs));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 delegated to Bob and token 2 undelegated.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must become delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_DelegatedInto_Undelegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 1
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 1;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (delegated) into token 2 (undelegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and should become delegated
+        // (mergeDelegateVotes: from=delegated, to=undelegated -> to becomes delegated)
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Both of Alice's tokens are delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_BothDelegated_ByApprovedThirdParty() public {
+        // Alice delegates to Bob (both tokens get delegated)
+        vm.prank(alice);
+        ivotesAdapter.delegate(bob);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 2);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 into token 2 (both delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+}

--- a/test/v1_2_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_2_0/integration/merge/delegate-approve-transfer.sol
@@ -34,4 +34,60 @@ contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice Alice has 3 tokens all delegated to Bob. Charlie merges token 1 into token 2.
+    ///         Alice transfers only the merged token to Dave.
+    ///         Bob retains voting power from token 3.
+    function test_Merge_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3); // tokenId 3
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        // Same start time — merge allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
+
+    /// @notice Same as above but Bob votes on a gauge first.
+    ///         After merge + partial transfer, Bob's gauge vote auto-decreases.
+    function test_Merge_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3);
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(totalAmount + amount3, elapsed));
+
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
 }

--- a/test/v1_2_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_2_0/integration/merge/delegate-approve-transfer.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        // Capture Bob's VP before transfer — Eve should receive the same amount
+        uint256 expectedVP = ivotesAdapter.getVotes(bob);
+
+        // Alice transfers the surviving token to whitelisted Dave (who already has Eve as delegatee)
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, _survivingTokenId);
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), true);
+        assertEq(nftLock.ownerOf(_survivingTokenId), dave);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), expectedVP);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_2_0/integration/merge/delegate-approve-undelegate.sol
+++ b/test/v1_2_0/integration/merge/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndMerge is TestMerge_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = _survivingTokenId;
+
+        vm.prank(alice);
+        ivotesAdapter.undelegate(tokenIds);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_2_0/integration/split/delegate-approve-base.sol
+++ b/test/v1_2_0/integration/split/delegate-approve-base.sol
@@ -1,0 +1,139 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+abstract contract TestSplit_ApproveDelegateBase is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 aliceAmount = 30e18;
+    uint256 checkpointTs;
+
+    function setUp() public virtual override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        vm.warp(1);
+        token.transfer(alice, aliceAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+        escrow.enableSplit();
+
+        // Alice creates a lock and delegates to Bob
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), aliceAmount);
+            escrow.createLock(aliceAmount);
+            ivotesAdapter.delegate(bob);
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+    }
+
+    function _approveCharlieAndSplit(uint256 _tokenId, uint256 _splitAmount) internal {
+        vm.prank(alice);
+        nftLock.approve(charlie, _tokenId);
+
+        vm.prank(charlie);
+        escrow.split(_tokenId, _splitAmount);
+    }
+
+    function _assertDelegatedToBob(uint256[] memory _tokenIds) internal view {
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), _tokenIds.length);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal virtual;
+
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+    }
+
+    /// @notice Alice creates a lock, delegates to Bob, approves Charlie,
+    ///         then Charlie splits Alice's veNFT.
+    ///         Both resulting tokens must remain delegated to Bob.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegation() public {
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
+    }
+
+    /// @notice Same as above but Bob votes on a gauge after receiving delegation.
+    ///         The recorded vote on the gauge must remain unchanged after split.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegationAndVotes() public {
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        // Bob votes on the gauge (he has the delegated voting power)
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+
+        // Bob's gauge vote unchanged (split doesn't change total amount)
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _removeDelegationAndAssert(tokenIds);
+    }
+
+    /// @notice Charlie splits Alice's delegated veNFT multiple times.
+    ///         All resulting tokens must remain delegated to Bob.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MultipleSplits_MaintainsDelegation() public {
+        // Charlie splits: tokenId 1 (30e18) -> tokenId 1 (20e18) + tokenId 2 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        // Charlie splits again: tokenId 1 (20e18) -> tokenId 1 (10e18) + tokenId 3 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        uint256[] memory tokenIds = new uint256[](3);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+        tokenIds[2] = 3;
+
+        _assertDelegatedToBob(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
+    }
+}

--- a/test/v1_2_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_2_0/integration/split/delegate-approve-transfer.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        // Alice transfers all tokens to whitelisted Dave (who already has Eve as delegatee)
+        vm.startPrank(alice);
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            nftLock.transferFrom(alice, dave, _tokenIds[i]);
+        }
+        vm.stopPrank();
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+            assertEq(nftLock.ownerOf(_tokenIds[i]), dave);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), _tokenIds.length);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_2_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_2_0/integration/split/delegate-approve-transfer.sol
@@ -36,4 +36,45 @@ contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice After split, Alice transfers only the split-off token to Dave.
+    ///         Bob retains voting power from the remaining token.
+    function test_Split_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 splitAmount = 5e18;
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
+
+    /// @notice After split + partial transfer, Bob's gauge vote decreases automatically
+    ///         to reflect only the remaining token's voting power.
+    function test_Split_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 splitAmount = 5e18;
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, elapsed));
+
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
 }

--- a/test/v1_2_0/integration/split/delegate-approve-undelegate.sol
+++ b/test/v1_2_0/integration/split/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndSplit is TestSplit_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        vm.prank(alice);
+        ivotesAdapter.undelegate(_tokenIds);
+
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), false);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        // Bob loses delegated voting power, Alice has none either (tokens are undelegated, not self-delegated)
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_2_0/unit/delegation/Base.sol
+++ b/test/v1_2_0/unit/delegation/Base.sol
@@ -17,7 +17,8 @@ import {
     EscrowIVotesAdapter,
     IEscrowIVotesAdapterStorage,
     IEscrowIVotesAdapterErrorsAndEvents,
-    SimpleGaugeVoter
+    SimpleGaugeVoter,
+    IVotingEscrowCore
 } from "../../versions.sol";
 
 import {ProxyLib} from "@libs/ProxyLib.sol";
@@ -28,6 +29,10 @@ import {FixedPointBase} from "../../base/FixedPointBase.sol";
 
 contract EscrowVotingPowerMock is IDelegateUpdateVotingPower {
     function updateVotingPower(address a, address b) external {}
+}
+
+contract MockLockNFT {
+    // This is a mock - actual ownerOf calls will be mocked via vm.mockCall
 }
 
 contract EscrowIVotesAdapterA is EscrowIVotesAdapter {
@@ -57,6 +62,7 @@ contract Base is
     using ProxyLib for address;
 
     EscrowVotingPowerMock public escrow;
+    MockLockNFT public lockNFT;
     SimpleGaugeVoter public voter;
     EscrowIVotesAdapterA public dg;
     DAO dao;
@@ -74,10 +80,12 @@ contract Base is
         _deployDAO();
         clock = _deployClock(address(dao));
         escrow = new EscrowVotingPowerMock();
+        lockNFT = new MockLockNFT();
         dg = _deployEscrowIVotesAdapter(address(dao), address(clock), address(escrow));
         voter = _deployVoter(address(dao), address(clock), address(escrow), address(dg));
 
-        _mockApprovedOwner(true);
+        _mockLockNFT();
+        _mockOwner(address(this));
 
         uint256 maxTime = IClock(clock).epochDuration() * CurveConstantLib.MAX_EPOCHS;
 
@@ -188,10 +196,34 @@ contract Base is
         assertEq(dg.slopeChanges_(_account, _end), slopeFP(_amount));
     }
 
-    function _mockApprovedOwner(bool _approved) internal {
+    function _mockLockNFT() internal {
         vm.mockCall(
             address(escrow),
-            abi.encodeWithSelector(VotingEscrow.isApprovedOrOwner.selector),
+            abi.encodeWithSelector(IVotingEscrowCore.lockNFT.selector),
+            abi.encode(address(lockNFT))
+        );
+    }
+
+    function _mockOwner(address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)"))),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockOwnerOf(uint256 _tokenId, address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)")), _tokenId),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockGetApproved(uint256 _tokenId, address _approved) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("getApproved(uint256)")), _tokenId),
             abi.encode(_approved)
         );
     }

--- a/test/v1_2_0/unit/delegation/Delegate.t.sol
+++ b/test/v1_2_0/unit/delegation/Delegate.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 import {Base} from "./Base.sol";
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {DaoUnauthorized} from "@aragon/osx-commons-contracts/src/permission/auth/auth.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract TestDelegate is Base {
     function setUp() public override {
@@ -151,13 +152,34 @@ contract TestDelegate is Base {
         dg.delegate(multiIds);
     }
 
-    function testRevert_IfNotApprovedOrOwner() public {
+    function testRevert_IfNotOwner() public {
         dg.setDelegateAddress(alice);
 
-        _mockApprovedOwner(false);
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.delegate(singleId);
+    }
+
+    function testRevert_IfNotOwnerOfOneTokenButOwnerOfAnother() public {
+        dg.setDelegateAddress(alice);
+
+        // sender (address(this)) owns token 1 but not token 2
+        // token 2 is owned by alice but approved to address(this)
+        _mockOwnerOf(multiIds[0], address(this));
+        _mockOwnerOf(multiIds[1], alice);
+        _mockGetApproved(multiIds[1], address(this));
+
+        // Verify that token 2 is approved to address(this)
+        assertEq(IERC721(address(lockNFT)).getApproved(multiIds[1]), address(this));
+
+        _mockLocked(multiIds[0], 10, weekStartTs(block.timestamp));
+        _mockLocked(multiIds[1], 10, weekStartTs(block.timestamp));
+
+        // Should fail because sender doesn't own token 2, even though it's approved
+        vm.expectRevert(NotOwner.selector);
+        dg.delegate(multiIds);
     }
 
     function testRevert_IfTokenAlreadyDelegated() public {

--- a/test/v1_2_0/unit/delegation/Undelegate.t.sol
+++ b/test/v1_2_0/unit/delegation/Undelegate.t.sol
@@ -45,10 +45,11 @@ contract TestUndelegate is Base {
         dg.undelegate(getIds(1));
     }
 
-    function testRevert_IfNotApprovedOrOwner() public givenDelegatedTokens {
-        _mockApprovedOwner(false);
+    function testRevert_IfNotOwner() public givenDelegatedTokens {
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.undelegate(multiIds);
     }
 

--- a/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -107,6 +107,9 @@ contract TestVPAndCheckpoints is Base {
 
         dg.undelegate(singleId);
 
+        // asserts latest global point.
+        assertGlobalPoint(alice, 1, 0, 0, block.timestamp);
+
         // slope must reflect the change as alice was undelegated.
         assertSlopeChange(alice, start + maxTime, 0);
     }
@@ -281,5 +284,150 @@ contract TestVPAndCheckpoints is Base {
         uint256 expectedTs = block.timestamp;
 
         assertGlobalPoint(alice, 2, biasFP(amount, maxTime), 0, expectedTs);
+    }
+
+     /*//////////////////////////////////////////////////////////////
+                  Same Timestamp Checkpoint Overwrite
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Tests that multiple delegate/undelegate operations at the same timestamp
+    ///         overwrite the same checkpoint instead of creating multiple checkpoints.
+    ///         This ensures binary search returns the correct final state.
+    function test_SameTimestampCheckpointOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        // Setup three tokens with different amounts
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // First delegation - creates checkpoint index 1
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Second delegation at same timestamp - should overwrite checkpoint index 1
+        dg.delegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+
+        // Undelegate at same timestamp - should still overwrite checkpoint index 1
+        dg.undelegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+
+        // Verify final state: only token1 is delegated
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(dg.getVotes(alice), expectedVP);
+
+        // Verify the checkpoint has the correct final values
+        GlobalPoint memory p = dg.pointHistory_(alice, 1);
+        assertEq(p.writtenTs, delegateTs);
+        assertEq(p.bias, biasFP(amount1, delegateTs - start));
+        assertEq(p.slope, slopeFP(amount1));
+    }
+
+    /// @notice Tests that binary search correctly returns the final checkpoint state
+    ///         when querying historical votes after checkpoint overwrite.
+    function test_BinarySearchReturnsCorrectStateAfterOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // Multiple operations at same timestamp
+        dg.delegate(getIds(tokenId1));
+        dg.delegate(getIds(tokenId2, tokenId3));
+        dg.undelegate(getIds(tokenId2, tokenId3));
+
+        // Only checkpoint index 1 should exist with final state
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to future and create a new checkpoint to force binary search path
+        vm.warp(block.timestamp + 1 weeks);
+        dg.checkpointTransition(alice, 1);
+
+        // Now we have checkpoint index 2 at a later timestamp
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Query historical votes at the original timestamp
+        // This will use binary search since we're querying a past timestamp
+        uint256 historicalVP = dg.getPastVotes(alice, delegateTs);
+
+        // Should return the final state (only token1 delegated), not inflated value
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(historicalVP, expectedVP);
+
+        // Verify it's NOT returning the inflated value (all three tokens)
+        uint256 inflatedVP = bias(amount1 + amount2 + amount3, delegateTs - start);
+        assertTrue(historicalVP != inflatedVP);
+    }
+
+    /// @notice Tests that checkpoints at different timestamps still create separate indices.
+    function test_DifferentTimestampsCreateSeparateCheckpoints() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 firstDelegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+
+        // First delegation at timestamp T
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to a different timestamp
+        vm.warp(block.timestamp + 1 weeks);
+        uint256 secondDelegateTs = block.timestamp;
+
+        // Second delegation at timestamp T+1week - should create new checkpoint
+        dg.delegate(getIds(tokenId2));
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Verify both checkpoints exist with correct timestamps
+        GlobalPoint memory p1 = dg.pointHistory_(alice, 1);
+        GlobalPoint memory p2 = dg.pointHistory_(alice, 2);
+        assertEq(p1.writtenTs, firstDelegateTs);
+        assertEq(p2.writtenTs, secondDelegateTs);
+
+        // Query historical votes at first timestamp
+        uint256 vpAtFirst = dg.getPastVotes(alice, firstDelegateTs);
+        assertEq(vpAtFirst, bias(amount1, firstDelegateTs - start));
+
+        // Query votes at second timestamp
+        uint256 vpAtSecond = dg.getPastVotes(alice, secondDelegateTs);
+        assertEq(vpAtSecond, bias(amount1, secondDelegateTs - start) + bias(amount2, secondDelegateTs - start));
     }
 }

--- a/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -317,14 +317,17 @@ contract TestVPAndCheckpoints is Base {
         // First delegation - creates checkpoint index 1
         dg.delegate(getIds(tokenId1));
         assertEq(dg.latestPointIndex(alice), 1);
+        assertEq(dg.getVotes(alice), amount1);
 
         // Second delegation at same timestamp - should overwrite checkpoint index 1
         dg.delegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+        assertEq(dg.getVotes(alice), amount1 + amount2 + amount3);
 
         // Undelegate at same timestamp - should still overwrite checkpoint index 1
         dg.undelegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+        assertEq(dg.getVotes(alice), amount1);
 
         // Verify final state: only token1 is delegated
         uint256 expectedVP = bias(amount1, delegateTs - start);

--- a/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_2_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -127,6 +127,7 @@ contract TestVPAndCheckpoints is Base {
             ids[0] = 1;
             vm.startPrank(bob);
             _mockLocked(ids[0], bobAmount, bobDelegateStart);
+            _mockOwnerOf(ids[0], bob);
             dg.setDelegateAddress(alice);
             dg.delegate(ids);
             dg.undelegate(ids);
@@ -145,6 +146,7 @@ contract TestVPAndCheckpoints is Base {
             uint256[] memory ids = new uint256[](1);
             ids[0] = 2;
             vm.startPrank(carol);
+            _mockOwnerOf(ids[0], carol);
             _mockLocked(ids[0], carolAmount, carolDelegateStart);
             dg.setDelegateAddress(alice);
             dg.delegate(ids);

--- a/test/v1_3_0/integration/merge/delegate-approve-base.sol
+++ b/test/v1_3_0/integration/merge/delegate-approve-base.sol
@@ -1,0 +1,221 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+abstract contract TestMerge_ApproveDelegateBase is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 amount1 = 15e18;
+    uint256 amount2 = 20e18;
+    uint256 totalAmount;
+
+    uint256 checkpointTs;
+    uint256 writtenTs;
+
+    function setUp() public virtual override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        totalAmount = amount1 + amount2;
+
+        vm.warp(1);
+        token.transfer(alice, totalAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+
+        // Alice creates 2 locks in the same block (same start time for merge compatibility)
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), totalAmount);
+            escrow.createLock(amount1); // tokenId 1
+            escrow.createLock(amount2); // tokenId 2
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+        writtenTs = block.timestamp;
+    }
+
+    function _warpPastMaturation() internal {
+        uint256 lockEnd = getEndTimestamp(checkpointTs, writtenTs);
+        vm.warp(lockEnd + 1 seconds);
+    }
+
+    function _approveCharlieAndMerge(uint256 _from, uint256 _to) internal {
+        vm.prank(alice);
+        nftLock.setApprovalForAll(charlie, true);
+
+        vm.prank(charlie);
+        escrow.merge(_from, _to);
+    }
+
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal virtual;
+
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Warp past maturation so locks can merge (different effective amounts but same start)
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (undelegated) into token 2 (delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Bob votes on a gauge with his delegated power.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Bob's gauge vote must remain unchanged after merge.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty_WithVote() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Bob votes on a gauge with his delegated voting power
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 bobVoteAtGauge = voter.votes(bob, gauge);
+        assertEq(bobVoteAtGauge, ivotesAdapter.getVotes(bob));
+
+        // Both locks have the same start time, so merge is allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, block.timestamp - checkpointTs));
+
+        // Bob's gauge vote unchanged from when he voted (pre-merge, only amount2 delegated)
+        assertEq(voter.votes(bob, gauge), bobVoteAtGauge);
+
+        // Bob revotes to use his increased voting power from the merge
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        // Bob's gauge vote now reflects the combined amount
+        assertEq(voter.votes(bob, gauge), bias(totalAmount, block.timestamp - checkpointTs));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 delegated to Bob and token 2 undelegated.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must become delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_DelegatedInto_Undelegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 1
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 1;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (delegated) into token 2 (undelegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and should become delegated
+        // (mergeDelegateVotes: from=delegated, to=undelegated -> to becomes delegated)
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Both of Alice's tokens are delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_BothDelegated_ByApprovedThirdParty() public {
+        // Alice delegates to Bob (both tokens get delegated)
+        vm.prank(alice);
+        ivotesAdapter.delegate(bob);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 2);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 into token 2 (both delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _removeDelegationAndAssert(2);
+    }
+}

--- a/test/v1_3_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_3_0/integration/merge/delegate-approve-transfer.sol
@@ -34,4 +34,60 @@ contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice Alice has 3 tokens all delegated to Bob. Charlie merges token 1 into token 2.
+    ///         Alice transfers only the merged token to Dave.
+    ///         Bob retains voting power from token 3.
+    function test_Merge_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3); // tokenId 3
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        // Same start time — merge allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
+
+    /// @notice Same as above but Bob votes on a gauge first.
+    ///         After merge + partial transfer, Bob's gauge vote auto-decreases.
+    function test_Merge_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3);
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(totalAmount + amount3, elapsed));
+
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
 }

--- a/test/v1_3_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_3_0/integration/merge/delegate-approve-transfer.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        // Capture Bob's VP before transfer — Eve should receive the same amount
+        uint256 expectedVP = ivotesAdapter.getVotes(bob);
+
+        // Alice transfers the surviving token to whitelisted Dave (who already has Eve as delegatee)
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, _survivingTokenId);
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), true);
+        assertEq(nftLock.ownerOf(_survivingTokenId), dave);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), expectedVP);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_3_0/integration/merge/delegate-approve-undelegate.sol
+++ b/test/v1_3_0/integration/merge/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndMerge is TestMerge_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = _survivingTokenId;
+
+        vm.prank(alice);
+        ivotesAdapter.undelegate(tokenIds);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_3_0/integration/split/delegate-approve-base.sol
+++ b/test/v1_3_0/integration/split/delegate-approve-base.sol
@@ -1,0 +1,139 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+abstract contract TestSplit_ApproveDelegateBase is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 aliceAmount = 30e18;
+    uint256 checkpointTs;
+
+    function setUp() public virtual override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        vm.warp(1);
+        token.transfer(alice, aliceAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+        escrow.enableSplit();
+
+        // Alice creates a lock and delegates to Bob
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), aliceAmount);
+            escrow.createLock(aliceAmount);
+            ivotesAdapter.delegate(bob);
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+    }
+
+    function _approveCharlieAndSplit(uint256 _tokenId, uint256 _splitAmount) internal {
+        vm.prank(alice);
+        nftLock.approve(charlie, _tokenId);
+
+        vm.prank(charlie);
+        escrow.split(_tokenId, _splitAmount);
+    }
+
+    function _assertDelegatedToBob(uint256[] memory _tokenIds) internal view {
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), _tokenIds.length);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal virtual;
+
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+    }
+
+    /// @notice Alice creates a lock, delegates to Bob, approves Charlie,
+    ///         then Charlie splits Alice's veNFT.
+    ///         Both resulting tokens must remain delegated to Bob.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegation() public {
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
+    }
+
+    /// @notice Same as above but Bob votes on a gauge after receiving delegation.
+    ///         The recorded vote on the gauge must remain unchanged after split.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegationAndVotes() public {
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        // Bob votes on the gauge (he has the delegated voting power)
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+
+        // Bob's gauge vote unchanged (split doesn't change total amount)
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _removeDelegationAndAssert(tokenIds);
+    }
+
+    /// @notice Charlie splits Alice's delegated veNFT multiple times.
+    ///         All resulting tokens must remain delegated to Bob.
+    ///         Alice then removes delegation successfully.
+    function test_Split_ByApprovedThirdParty_MultipleSplits_MaintainsDelegation() public {
+        // Charlie splits: tokenId 1 (30e18) -> tokenId 1 (20e18) + tokenId 2 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        // Charlie splits again: tokenId 1 (20e18) -> tokenId 1 (10e18) + tokenId 3 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        uint256[] memory tokenIds = new uint256[](3);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+        tokenIds[2] = 3;
+
+        _assertDelegatedToBob(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
+    }
+}

--- a/test/v1_3_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_3_0/integration/split/delegate-approve-transfer.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        // Alice transfers all tokens to whitelisted Dave (who already has Eve as delegatee)
+        vm.startPrank(alice);
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            nftLock.transferFrom(alice, dave, _tokenIds[i]);
+        }
+        vm.stopPrank();
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+            assertEq(nftLock.ownerOf(_tokenIds[i]), dave);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), _tokenIds.length);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_3_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_3_0/integration/split/delegate-approve-transfer.sol
@@ -36,4 +36,45 @@ contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice After split, Alice transfers only the split-off token to Dave.
+    ///         Bob retains voting power from the remaining token.
+    function test_Split_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 splitAmount = 5e18;
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
+
+    /// @notice After split + partial transfer, Bob's gauge vote decreases automatically
+    ///         to reflect only the remaining token's voting power.
+    function test_Split_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 splitAmount = 5e18;
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, elapsed));
+
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
 }

--- a/test/v1_3_0/integration/split/delegate-approve-undelegate.sol
+++ b/test/v1_3_0/integration/split/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndSplit is TestSplit_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        vm.prank(alice);
+        ivotesAdapter.undelegate(_tokenIds);
+
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), false);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        // Bob loses delegated voting power, Alice has none either (tokens are undelegated, not self-delegated)
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_3_0/unit/delegation/Base.sol
+++ b/test/v1_3_0/unit/delegation/Base.sol
@@ -17,7 +17,8 @@ import {
     EscrowIVotesAdapter,
     IEscrowIVotesAdapterStorage,
     IEscrowIVotesAdapterErrorsAndEvents,
-    SimpleGaugeVoter
+    SimpleGaugeVoter,
+    IVotingEscrowCore
 } from "../../versions.sol";
 
 import {ProxyLib} from "@libs/ProxyLib.sol";
@@ -28,6 +29,10 @@ import {FixedPointBase} from "../../base/FixedPointBase.sol";
 
 contract EscrowVotingPowerMock is IDelegateUpdateVotingPower {
     function updateVotingPower(address a, address b) external {}
+}
+
+contract MockLockNFT {
+    // This is a mock - actual ownerOf calls will be mocked via vm.mockCall
 }
 
 contract EscrowIVotesAdapterA is EscrowIVotesAdapter {
@@ -57,6 +62,7 @@ contract Base is
     using ProxyLib for address;
 
     EscrowVotingPowerMock public escrow;
+    MockLockNFT public lockNFT;
     SimpleGaugeVoter public voter;
     EscrowIVotesAdapterA public dg;
     DAO dao;
@@ -74,10 +80,12 @@ contract Base is
         _deployDAO();
         clock = _deployClock(address(dao));
         escrow = new EscrowVotingPowerMock();
+        lockNFT = new MockLockNFT();
         dg = _deployEscrowIVotesAdapter(address(dao), address(clock), address(escrow));
         voter = _deployVoter(address(dao), address(clock), address(escrow), address(dg));
 
-        _mockApprovedOwner(true);
+        _mockLockNFT();
+        _mockOwner(address(this));
         // _mockPermissions();
 
         uint256 maxTime = IClock(clock).epochDuration() * CurveConstantLib.MAX_EPOCHS;
@@ -189,10 +197,34 @@ contract Base is
         assertEq(dg.slopeChanges_(_account, _end), slopeFP(_amount));
     }
 
-    function _mockApprovedOwner(bool _approved) internal {
+    function _mockLockNFT() internal {
         vm.mockCall(
             address(escrow),
-            abi.encodeWithSelector(VotingEscrow.isApprovedOrOwner.selector),
+            abi.encodeWithSelector(IVotingEscrowCore.lockNFT.selector),
+            abi.encode(address(lockNFT))
+        );
+    }
+
+    function _mockOwner(address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)"))),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockOwnerOf(uint256 _tokenId, address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)")), _tokenId),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockGetApproved(uint256 _tokenId, address _approved) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("getApproved(uint256)")), _tokenId),
             abi.encode(_approved)
         );
     }

--- a/test/v1_3_0/unit/delegation/Delegate.t.sol
+++ b/test/v1_3_0/unit/delegation/Delegate.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 import {Base} from "./Base.sol";
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {DaoUnauthorized} from "@aragon/osx-commons-contracts/src/permission/auth/auth.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract TestDelegate is Base {
     function setUp() public override {
@@ -151,13 +152,34 @@ contract TestDelegate is Base {
         dg.delegate(multiIds);
     }
 
-    function testRevert_IfNotApprovedOrOwner() public {
+    function testRevert_IfNotOwner() public {
         dg.setDelegateAddress(alice);
 
-        _mockApprovedOwner(false);
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.delegate(singleId);
+    }
+
+    function testRevert_IfNotOwnerOfOneTokenButOwnerOfAnother() public {
+        dg.setDelegateAddress(alice);
+
+        // sender (address(this)) owns token 1 but not token 2
+        // token 2 is owned by alice but approved to address(this)
+        _mockOwnerOf(multiIds[0], address(this));
+        _mockOwnerOf(multiIds[1], alice);
+        _mockGetApproved(multiIds[1], address(this));
+
+        // Verify that token 2 is approved to address(this)
+        assertEq(IERC721(address(lockNFT)).getApproved(multiIds[1]), address(this));
+
+        _mockLocked(multiIds[0], 10, weekStartTs(block.timestamp));
+        _mockLocked(multiIds[1], 10, weekStartTs(block.timestamp));
+
+        // Should fail because sender doesn't own token 2, even though it's approved
+        vm.expectRevert(NotOwner.selector);
+        dg.delegate(multiIds);
     }
 
     function testRevert_IfTokenAlreadyDelegated() public {

--- a/test/v1_3_0/unit/delegation/Undelegate.t.sol
+++ b/test/v1_3_0/unit/delegation/Undelegate.t.sol
@@ -45,10 +45,11 @@ contract TestUndelegate is Base {
         dg.undelegate(getIds(1));
     }
 
-    function testRevert_IfNotApprovedOrOwner() public givenDelegatedTokens {
-        _mockApprovedOwner(false);
+    function testRevert_IfNotOwner() public givenDelegatedTokens {
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.undelegate(multiIds);
     }
 

--- a/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -131,6 +131,7 @@ contract TestVPAndCheckpoints is Base {
             ids[0] = 1;
             vm.startPrank(bob);
             _mockLocked(ids[0], bobAmount, bobDelegateStart);
+            _mockOwnerOf(ids[0], bob);
             dg.setDelegateAddress(alice);
             dg.delegate(ids);
             dg.undelegate(ids);
@@ -150,6 +151,7 @@ contract TestVPAndCheckpoints is Base {
             ids[0] = 2;
             vm.startPrank(carol);
             _mockLocked(ids[0], carolAmount, carolDelegateStart);
+            _mockOwnerOf(ids[0], carol);
             dg.setDelegateAddress(alice);
             dg.delegate(ids);
             vm.stopPrank();

--- a/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -109,7 +109,7 @@ contract TestVPAndCheckpoints is Base {
         dg.undelegate(singleId);
 
         // asserts latest global point.
-        assertGlobalPoint(alice, 2, 0, 0, block.timestamp);
+        assertGlobalPoint(alice, 1, 0, 0, block.timestamp);
 
         // slope must reflect the change as alice was undelegated.
         assertSlopeChange(alice, start + maxTime, 0);
@@ -286,5 +286,150 @@ contract TestVPAndCheckpoints is Base {
         uint256 expectedTs = block.timestamp;
 
         assertGlobalPoint(alice, 2, biasFP(amount, maxTime), 0, expectedTs);
+    }
+
+     /*//////////////////////////////////////////////////////////////
+                  Same Timestamp Checkpoint Overwrite
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Tests that multiple delegate/undelegate operations at the same timestamp
+    ///         overwrite the same checkpoint instead of creating multiple checkpoints.
+    ///         This ensures binary search returns the correct final state.
+    function test_SameTimestampCheckpointOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        // Setup three tokens with different amounts
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // First delegation - creates checkpoint index 1
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Second delegation at same timestamp - should overwrite checkpoint index 1
+        dg.delegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+
+        // Undelegate at same timestamp - should still overwrite checkpoint index 1
+        dg.undelegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+
+        // Verify final state: only token1 is delegated
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(dg.getVotes(alice), expectedVP);
+
+        // Verify the checkpoint has the correct final values
+        GlobalPoint memory p = dg.pointHistory_(alice, 1);
+        assertEq(p.writtenTs, delegateTs);
+        assertEq(p.bias, biasFP(amount1, delegateTs - start));
+        assertEq(p.slope, slopeFP(amount1));
+    }
+
+    /// @notice Tests that binary search correctly returns the final checkpoint state
+    ///         when querying historical votes after checkpoint overwrite.
+    function test_BinarySearchReturnsCorrectStateAfterOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // Multiple operations at same timestamp
+        dg.delegate(getIds(tokenId1));
+        dg.delegate(getIds(tokenId2, tokenId3));
+        dg.undelegate(getIds(tokenId2, tokenId3));
+
+        // Only checkpoint index 1 should exist with final state
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to future and create a new checkpoint to force binary search path
+        vm.warp(block.timestamp + 1 weeks);
+        dg.checkpointTransition(alice, 1);
+
+        // Now we have checkpoint index 2 at a later timestamp
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Query historical votes at the original timestamp
+        // This will use binary search since we're querying a past timestamp
+        uint256 historicalVP = dg.getPastVotes(alice, delegateTs);
+
+        // Should return the final state (only token1 delegated), not inflated value
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(historicalVP, expectedVP);
+
+        // Verify it's NOT returning the inflated value (all three tokens)
+        uint256 inflatedVP = bias(amount1 + amount2 + amount3, delegateTs - start);
+        assertTrue(historicalVP != inflatedVP);
+    }
+
+    /// @notice Tests that checkpoints at different timestamps still create separate indices.
+    function test_DifferentTimestampsCreateSeparateCheckpoints() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 firstDelegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+
+        // First delegation at timestamp T
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to a different timestamp
+        vm.warp(block.timestamp + 1 weeks);
+        uint256 secondDelegateTs = block.timestamp;
+
+        // Second delegation at timestamp T+1week - should create new checkpoint
+        dg.delegate(getIds(tokenId2));
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Verify both checkpoints exist with correct timestamps
+        GlobalPoint memory p1 = dg.pointHistory_(alice, 1);
+        GlobalPoint memory p2 = dg.pointHistory_(alice, 2);
+        assertEq(p1.writtenTs, firstDelegateTs);
+        assertEq(p2.writtenTs, secondDelegateTs);
+
+        // Query historical votes at first timestamp
+        uint256 vpAtFirst = dg.getPastVotes(alice, firstDelegateTs);
+        assertEq(vpAtFirst, bias(amount1, firstDelegateTs - start));
+
+        // Query votes at second timestamp
+        uint256 vpAtSecond = dg.getPastVotes(alice, secondDelegateTs);
+        assertEq(vpAtSecond, bias(amount1, secondDelegateTs - start) + bias(amount2, secondDelegateTs - start));
     }
 }

--- a/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_3_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -319,14 +319,17 @@ contract TestVPAndCheckpoints is Base {
         // First delegation - creates checkpoint index 1
         dg.delegate(getIds(tokenId1));
         assertEq(dg.latestPointIndex(alice), 1);
+        assertEq(dg.getVotes(alice), amount1);
 
         // Second delegation at same timestamp - should overwrite checkpoint index 1
         dg.delegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+        assertEq(dg.getVotes(alice), amount1 + amount2 + amount3);
 
         // Undelegate at same timestamp - should still overwrite checkpoint index 1
         dg.undelegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+        assertEq(dg.getVotes(alice), amount1);
 
         // Verify final state: only token1 is delegated
         uint256 expectedVP = bias(amount1, delegateTs - start);

--- a/test/v1_4_0/integration/merge/approve-delegate.sol
+++ b/test/v1_4_0/integration/merge/approve-delegate.sol
@@ -1,0 +1,176 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+contract TestMerge_ApproveDelegateAndMerge is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 amount1 = 15e18;
+    uint256 amount2 = 20e18;
+    uint256 totalAmount;
+
+    uint256 checkpointTs;
+    uint256 writtenTs;
+
+    function setUp() public override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        totalAmount = amount1 + amount2;
+
+        vm.warp(1);
+        token.transfer(alice, totalAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+
+        // Alice creates 2 locks in the same block (same start time for merge compatibility)
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), totalAmount);
+            escrow.createLock(amount1); // tokenId 1
+            escrow.createLock(amount2); // tokenId 2
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+        writtenTs = block.timestamp;
+    }
+
+    function _warpPastMaturation() internal {
+        uint256 lockEnd = getEndTimestamp(checkpointTs, writtenTs);
+        vm.warp(lockEnd + 1 seconds);
+    }
+
+    function _approveCharlieAndMerge(uint256 _from, uint256 _to) internal {
+        vm.prank(alice);
+        nftLock.setApprovalForAll(charlie, true);
+
+        vm.prank(charlie);
+        escrow.merge(_from, _to);
+    }
+
+    function _undelegateAndAssert(uint256 _survivingTokenId) internal {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = _survivingTokenId;
+
+        vm.prank(alice);
+        ivotesAdapter.undelegate(tokenIds);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then undelegates successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Warp past maturation so locks can merge (different effective amounts but same start)
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (undelegated) into token 2 (delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _undelegateAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 delegated to Bob and token 2 undelegated.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must become delegated to Bob with combined voting power.
+    ///         Alice then undelegates successfully.
+    function test_Merge_DelegatedInto_Undelegated_ByApprovedThirdParty() public {
+        // Alice sets Bob as delegatee and only delegates token 1
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 1;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 (delegated) into token 2 (undelegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and should become delegated
+        // (mergeDelegateVotes: from=delegated, to=undelegated -> to becomes delegated)
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _undelegateAndAssert(2);
+    }
+
+    /// @notice Both of Alice's tokens are delegated to Bob.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Alice then undelegates successfully.
+    function test_Merge_BothDelegated_ByApprovedThirdParty() public {
+        // Alice delegates to Bob (both tokens get delegated)
+        vm.prank(alice);
+        ivotesAdapter.delegate(bob);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), true);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 2);
+
+        _warpPastMaturation();
+
+        // Charlie merges token 1 into token 2 (both delegated)
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
+
+        _undelegateAndAssert(2);
+    }
+}

--- a/test/v1_4_0/integration/merge/delegate-approve-base.sol
+++ b/test/v1_4_0/integration/merge/delegate-approve-base.sol
@@ -19,7 +19,7 @@ import {
     IEscrowCurveGlobalStorage
 } from "../../versions.sol";
 
-contract TestMerge_ApproveDelegateAndMerge is
+abstract contract TestMerge_ApproveDelegateBase is
     IEscrowCurveTokenStorage,
     IEscrowCurveGlobalStorage,
     EscrowBase
@@ -35,7 +35,7 @@ contract TestMerge_ApproveDelegateAndMerge is
     uint256 checkpointTs;
     uint256 writtenTs;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
         super.mintAndApproveEscrow();
 
@@ -71,23 +71,17 @@ contract TestMerge_ApproveDelegateAndMerge is
         escrow.merge(_from, _to);
     }
 
-    function _undelegateAndAssert(uint256 _survivingTokenId) internal {
-        uint256[] memory tokenIds = new uint256[](1);
-        tokenIds[0] = _survivingTokenId;
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal virtual;
 
-        vm.prank(alice);
-        ivotesAdapter.undelegate(tokenIds);
-
-        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), false);
-        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
-        assertEq(ivotesAdapter.getVotes(bob), 0);
-        assertEq(ivotesAdapter.getVotes(alice), 0);
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
     }
 
     /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
     ///         Charlie (approved) merges token 1 into token 2.
     ///         The surviving token 2 must remain delegated to Bob with combined voting power.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty() public {
         // Alice sets Bob as delegatee and only delegates token 2
         uint256[] memory delegateIds = new uint256[](1);
@@ -113,13 +107,64 @@ contract TestMerge_ApproveDelegateAndMerge is
         // Bob's voting power should reflect the combined amount
         assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
 
-        _undelegateAndAssert(2);
+        _removeDelegationAndAssert(2);
+    }
+
+    /// @notice Alice has token 1 undelegated and token 2 delegated to Bob.
+    ///         Bob votes on a gauge with his delegated power.
+    ///         Charlie (approved) merges token 1 into token 2.
+    ///         The surviving token 2 must remain delegated to Bob with combined voting power.
+    ///         Bob's gauge vote must remain unchanged after merge.
+    ///         Alice then removes delegation successfully.
+    function test_Merge_UndelegatedInto_Delegated_ByApprovedThirdParty_WithVote() public {
+        // Alice sets Bob as delegatee and only delegates token 2
+        uint256[] memory delegateIds = new uint256[](1);
+        delegateIds[0] = 2;
+        vm.startPrank(alice);
+        ivotesAdapter.setDelegateAddress(bob);
+        ivotesAdapter.delegate(delegateIds);
+        vm.stopPrank();
+
+        assertEq(ivotesAdapter.tokenIsDelegated(1), false);
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+
+        // Bob votes on a gauge with his delegated voting power
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 bobVoteAtGauge = voter.votes(bob, gauge);
+        assertEq(bobVoteAtGauge, ivotesAdapter.getVotes(bob));
+
+        // Both locks have the same start time, so merge is allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        // Token 1 is burned, token 2 survives and remains delegated
+        assertEq(ivotesAdapter.tokenIsDelegated(2), true);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        // Bob's voting power should reflect the combined amount
+        assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, block.timestamp - checkpointTs));
+
+        // Bob's gauge vote unchanged from when he voted (pre-merge, only amount2 delegated)
+        assertEq(voter.votes(bob, gauge), bobVoteAtGauge);
+
+        // Bob revotes to use his increased voting power from the merge
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        // Bob's gauge vote now reflects the combined amount
+        assertEq(voter.votes(bob, gauge), bias(totalAmount, block.timestamp - checkpointTs));
+
+        _removeDelegationAndAssert(2);
     }
 
     /// @notice Alice has token 1 delegated to Bob and token 2 undelegated.
     ///         Charlie (approved) merges token 1 into token 2.
     ///         The surviving token 2 must become delegated to Bob with combined voting power.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Merge_DelegatedInto_Undelegated_ByApprovedThirdParty() public {
         // Alice sets Bob as delegatee and only delegates token 1
         uint256[] memory delegateIds = new uint256[](1);
@@ -144,13 +189,13 @@ contract TestMerge_ApproveDelegateAndMerge is
         assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
         assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
 
-        _undelegateAndAssert(2);
+        _removeDelegationAndAssert(2);
     }
 
     /// @notice Both of Alice's tokens are delegated to Bob.
     ///         Charlie (approved) merges token 1 into token 2.
     ///         The surviving token 2 must remain delegated to Bob with combined voting power.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Merge_BothDelegated_ByApprovedThirdParty() public {
         // Alice delegates to Bob (both tokens get delegated)
         vm.prank(alice);
@@ -171,6 +216,6 @@ contract TestMerge_ApproveDelegateAndMerge is
         assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
         assertEq(ivotesAdapter.getVotes(bob), bias(totalAmount, maxTime));
 
-        _undelegateAndAssert(2);
+        _removeDelegationAndAssert(2);
     }
 }

--- a/test/v1_4_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_4_0/integration/merge/delegate-approve-transfer.sol
@@ -34,4 +34,60 @@ contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice Alice has 3 tokens all delegated to Bob. Charlie merges token 1 into token 2.
+    ///         Alice transfers only the merged token to Dave.
+    ///         Bob retains voting power from token 3.
+    function test_Merge_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3); // tokenId 3
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        // Same start time — merge allowed without maturation
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
+
+    /// @notice Same as above but Bob votes on a gauge first.
+    ///         After merge + partial transfer, Bob's gauge vote auto-decreases.
+    function test_Merge_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 amount3 = 10e18;
+        token.transfer(alice, amount3);
+        vm.startPrank(alice);
+        token.approve(address(escrow), amount3);
+        escrow.createLock(amount3);
+        ivotesAdapter.delegate(bob);
+        vm.stopPrank();
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(totalAmount + amount3, elapsed));
+
+        _approveCharlieAndMerge(1, 2);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(amount3, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(totalAmount, elapsed));
+    }
 }

--- a/test/v1_4_0/integration/merge/delegate-approve-transfer.sol
+++ b/test/v1_4_0/integration/merge/delegate-approve-transfer.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndTransfer is TestMerge_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        // Capture Bob's VP before transfer — Eve should receive the same amount
+        uint256 expectedVP = ivotesAdapter.getVotes(bob);
+
+        // Alice transfers the surviving token to whitelisted Dave (who already has Eve as delegatee)
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, _survivingTokenId);
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), true);
+        assertEq(nftLock.ownerOf(_survivingTokenId), dave);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), expectedVP);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_4_0/integration/merge/delegate-approve-undelegate.sol
+++ b/test/v1_4_0/integration/merge/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestMerge_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestMerge_ApproveDelegateAndMerge is TestMerge_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256 _survivingTokenId) internal override {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = _survivingTokenId;
+
+        vm.prank(alice);
+        ivotesAdapter.undelegate(tokenIds);
+
+        assertEq(ivotesAdapter.tokenIsDelegated(_survivingTokenId), false);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_4_0/integration/split/approve-delegate.sol
+++ b/test/v1_4_0/integration/split/approve-delegate.sol
@@ -1,0 +1,150 @@
+pragma solidity ^0.8.17;
+
+import {EscrowBase, IAddressGaugeVote} from "../../base/EscrowBase.sol";
+
+import {
+    Clock,
+    IClock,
+    Lock,
+    VotingEscrow,
+    IVotingEscrowIncreasing,
+    IEscrowCurveIncreasing,
+    IVotingEscrowIncreasing,
+    IVotingEscrowCoreErrors,
+    IMerge,
+    ISplit,
+    ILockedBalanceIncreasing,
+    IEscrowCurveGlobalStorage,
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage
+} from "../../versions.sol";
+
+contract TestSplit_ApproveDelegateAndSplit is
+    IEscrowCurveTokenStorage,
+    IEscrowCurveGlobalStorage,
+    EscrowBase
+{
+    address alice = address(0x123);
+    address bob = address(0x456);
+    address charlie = address(0x789);
+
+    uint256 aliceAmount = 30e18;
+    uint256 checkpointTs;
+
+    function setUp() public override {
+        super.setUp();
+        super.mintAndApproveEscrow();
+
+        vm.warp(1);
+        token.transfer(alice, aliceAmount);
+        vm.warp(2 weeks + 1 hours + 1);
+        escrow.enableSplit();
+
+        // Alice creates a lock and delegates to Bob
+        vm.startPrank(alice);
+        {
+            token.approve(address(escrow), aliceAmount);
+            escrow.createLock(aliceAmount);
+            ivotesAdapter.delegate(bob);
+        }
+        vm.stopPrank();
+
+        checkpointTs = weekStartTs(block.timestamp);
+    }
+
+    function _approveCharlieAndSplit(uint256 _tokenId, uint256 _splitAmount) internal {
+        vm.prank(alice);
+        nftLock.approve(charlie, _tokenId);
+
+        vm.prank(charlie);
+        escrow.split(_tokenId, _splitAmount);
+    }
+
+    function _assertDelegatedToBob(uint256[] memory _tokenIds) internal view {
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), _tokenIds.length);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+
+    function _undelegateAndAssert(uint256[] memory _tokenIds) internal {
+        vm.prank(alice);
+        ivotesAdapter.undelegate(_tokenIds);
+
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), false);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        // Bob loses delegated voting power, Alice has none either (tokens are undelegated, not self-delegated)
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+
+    /// @notice Alice creates a lock, delegates to Bob, approves Charlie,
+    ///         then Charlie splits Alice's veNFT.
+    ///         Both resulting tokens must remain delegated to Bob.
+    ///         Alice then undelegates successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegation() public {
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+        _undelegateAndAssert(tokenIds);
+    }
+
+    /// @notice Same as above but Bob votes on a gauge after receiving delegation.
+    ///         The recorded vote on the gauge must remain unchanged after split.
+    ///         Alice then undelegates successfully.
+    function test_Split_ByApprovedThirdParty_MaintainsDelegationAndVotes() public {
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        // Bob votes on the gauge (he has the delegated voting power)
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _approveCharlieAndSplit(1, 5e18);
+
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+
+        _assertDelegatedToBob(tokenIds);
+
+        // Bob's gauge vote unchanged (split doesn't change total amount)
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
+
+        _undelegateAndAssert(tokenIds);
+    }
+
+    /// @notice Charlie splits Alice's delegated veNFT multiple times.
+    ///         All resulting tokens must remain delegated to Bob.
+    ///         Alice then undelegates successfully.
+    function test_Split_ByApprovedThirdParty_MultipleSplits_MaintainsDelegation() public {
+        // Charlie splits: tokenId 1 (30e18) -> tokenId 1 (20e18) + tokenId 2 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        // Charlie splits again: tokenId 1 (20e18) -> tokenId 1 (10e18) + tokenId 3 (10e18)
+        _approveCharlieAndSplit(1, 10e18);
+
+        uint256[] memory tokenIds = new uint256[](3);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+        tokenIds[2] = 3;
+
+        _assertDelegatedToBob(tokenIds);
+        _undelegateAndAssert(tokenIds);
+    }
+
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+    }
+}

--- a/test/v1_4_0/integration/split/delegate-approve-base.sol
+++ b/test/v1_4_0/integration/split/delegate-approve-base.sol
@@ -19,7 +19,7 @@ import {
     IEscrowCurveGlobalStorage
 } from "../../versions.sol";
 
-contract TestSplit_ApproveDelegateAndSplit is
+abstract contract TestSplit_ApproveDelegateBase is
     IEscrowCurveTokenStorage,
     IEscrowCurveGlobalStorage,
     EscrowBase
@@ -31,7 +31,7 @@ contract TestSplit_ApproveDelegateAndSplit is
     uint256 aliceAmount = 30e18;
     uint256 checkpointTs;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
         super.mintAndApproveEscrow();
 
@@ -69,23 +69,17 @@ contract TestSplit_ApproveDelegateAndSplit is
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
 
-    function _undelegateAndAssert(uint256[] memory _tokenIds) internal {
-        vm.prank(alice);
-        ivotesAdapter.undelegate(_tokenIds);
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal virtual;
 
-        for (uint256 i = 0; i < _tokenIds.length; i++) {
-            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), false);
-        }
-        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
-        // Bob loses delegated voting power, Alice has none either (tokens are undelegated, not self-delegated)
-        assertEq(ivotesAdapter.getVotes(bob), 0);
-        assertEq(ivotesAdapter.getVotes(alice), 0);
+    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
+        votes = new IAddressGaugeVote.GaugeVote[](1);
+        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
     }
 
     /// @notice Alice creates a lock, delegates to Bob, approves Charlie,
     ///         then Charlie splits Alice's veNFT.
     ///         Both resulting tokens must remain delegated to Bob.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Split_ByApprovedThirdParty_MaintainsDelegation() public {
         _approveCharlieAndSplit(1, 5e18);
 
@@ -94,12 +88,12 @@ contract TestSplit_ApproveDelegateAndSplit is
         tokenIds[1] = 2;
 
         _assertDelegatedToBob(tokenIds);
-        _undelegateAndAssert(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
     }
 
     /// @notice Same as above but Bob votes on a gauge after receiving delegation.
     ///         The recorded vote on the gauge must remain unchanged after split.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Split_ByApprovedThirdParty_MaintainsDelegationAndVotes() public {
         address gauge = address(0x777);
         voter.createGauge(gauge, "metadata");
@@ -121,12 +115,12 @@ contract TestSplit_ApproveDelegateAndSplit is
         // Bob's gauge vote unchanged (split doesn't change total amount)
         assertEq(voter.votes(bob, gauge), bias(aliceAmount, block.timestamp - checkpointTs));
 
-        _undelegateAndAssert(tokenIds);
+        _removeDelegationAndAssert(tokenIds);
     }
 
     /// @notice Charlie splits Alice's delegated veNFT multiple times.
     ///         All resulting tokens must remain delegated to Bob.
-    ///         Alice then undelegates successfully.
+    ///         Alice then removes delegation successfully.
     function test_Split_ByApprovedThirdParty_MultipleSplits_MaintainsDelegation() public {
         // Charlie splits: tokenId 1 (30e18) -> tokenId 1 (20e18) + tokenId 2 (10e18)
         _approveCharlieAndSplit(1, 10e18);
@@ -140,11 +134,6 @@ contract TestSplit_ApproveDelegateAndSplit is
         tokenIds[2] = 3;
 
         _assertDelegatedToBob(tokenIds);
-        _undelegateAndAssert(tokenIds);
-    }
-
-    function _singleVote(address _gauge) internal pure returns (IAddressGaugeVote.GaugeVote[] memory votes) {
-        votes = new IAddressGaugeVote.GaugeVote[](1);
-        votes[0] = IAddressGaugeVote.GaugeVote(100, _gauge);
+        _removeDelegationAndAssert(tokenIds);
     }
 }

--- a/test/v1_4_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_4_0/integration/split/delegate-approve-transfer.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
+    address dave = address(0xABC);
+    address eve = address(0xDEF);
+
+    function setUp() public override {
+        super.setUp();
+        nftLock.setWhitelisted(dave, true);
+
+        // Dave sets Eve as his delegatee before receiving any tokens
+        vm.prank(dave);
+        ivotesAdapter.setDelegateAddress(eve);
+    }
+
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        // Alice transfers all tokens to whitelisted Dave (who already has Eve as delegatee)
+        vm.startPrank(alice);
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            nftLock.transferFrom(alice, dave, _tokenIds[i]);
+        }
+        vm.stopPrank();
+
+        // Transfer auto-delegates to Dave's pre-set delegatee Eve
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), true);
+            assertEq(nftLock.ownerOf(_tokenIds[i]), dave);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), _tokenIds.length);
+        // Eve now holds the voting power that Bob previously had
+        assertEq(ivotesAdapter.getVotes(eve), bias(aliceAmount, block.timestamp - checkpointTs));
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(dave), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_4_0/integration/split/delegate-approve-transfer.sol
+++ b/test/v1_4_0/integration/split/delegate-approve-transfer.sol
@@ -36,4 +36,45 @@ contract TestSplit_ApproveDelegateAndTransfer is TestSplit_ApproveDelegateBase {
         assertEq(ivotesAdapter.getVotes(dave), 0);
         assertEq(ivotesAdapter.getVotes(alice), 0);
     }
+
+    /// @notice After split, Alice transfers only the split-off token to Dave.
+    ///         Bob retains voting power from the remaining token.
+    function test_Split_PartialTransfer_BobRetainsRemainingPower() public {
+        uint256 splitAmount = 5e18;
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 1);
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(dave), 1);
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
+
+    /// @notice After split + partial transfer, Bob's gauge vote decreases automatically
+    ///         to reflect only the remaining token's voting power.
+    function test_Split_PartialTransfer_BobGaugeVoteDecreases() public {
+        uint256 splitAmount = 5e18;
+
+        address gauge = address(0x777);
+        voter.createGauge(gauge, "metadata");
+
+        vm.prank(bob);
+        voter.vote(_singleVote(gauge));
+
+        uint256 elapsed = block.timestamp - checkpointTs;
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount, elapsed));
+
+        _approveCharlieAndSplit(1, splitAmount);
+
+        vm.prank(alice);
+        nftLock.transferFrom(alice, dave, 2);
+
+        // Bob's gauge vote auto-decreases without revoting
+        assertEq(voter.votes(bob, gauge), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(bob), bias(aliceAmount - splitAmount, elapsed));
+        assertEq(ivotesAdapter.getVotes(eve), bias(splitAmount, elapsed));
+    }
 }

--- a/test/v1_4_0/integration/split/delegate-approve-undelegate.sol
+++ b/test/v1_4_0/integration/split/delegate-approve-undelegate.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.17;
+
+import {TestSplit_ApproveDelegateBase} from "./delegate-approve-base.sol";
+
+contract TestSplit_ApproveDelegateAndSplit is TestSplit_ApproveDelegateBase {
+    function _removeDelegationAndAssert(uint256[] memory _tokenIds) internal override {
+        vm.prank(alice);
+        ivotesAdapter.undelegate(_tokenIds);
+
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            assertEq(ivotesAdapter.tokenIsDelegated(_tokenIds[i]), false);
+        }
+        assertEq(ivotesAdapter.numberOfDelegatedTokens(alice), 0);
+        // Bob loses delegated voting power, Alice has none either (tokens are undelegated, not self-delegated)
+        assertEq(ivotesAdapter.getVotes(bob), 0);
+        assertEq(ivotesAdapter.getVotes(alice), 0);
+    }
+}

--- a/test/v1_4_0/unit/delegation/Base.sol
+++ b/test/v1_4_0/unit/delegation/Base.sol
@@ -17,7 +17,8 @@ import {
     EscrowIVotesAdapter,
     IEscrowIVotesAdapterStorage,
     IEscrowIVotesAdapterErrorsAndEvents,
-    SimpleGaugeVoter
+    SimpleGaugeVoter,
+    IVotingEscrowCore
 } from "../../versions.sol";
 
 import {ProxyLib} from "@libs/ProxyLib.sol";
@@ -28,6 +29,10 @@ import {FixedPointBase} from "../../base/FixedPointBase.sol";
 
 contract EscrowVotingPowerMock is IDelegateUpdateVotingPower {
     function updateVotingPower(address a, address b) external {}
+}
+
+contract MockLockNFT {
+    // This is a mock - actual ownerOf calls will be mocked via vm.mockCall
 }
 
 contract EscrowIVotesAdapterA is EscrowIVotesAdapter {
@@ -57,6 +62,7 @@ contract Base is
     using ProxyLib for address;
 
     EscrowVotingPowerMock public escrow;
+    MockLockNFT public lockNFT;
     SimpleGaugeVoter public voter;
     EscrowIVotesAdapterA public dg;
     DAO dao;
@@ -74,10 +80,12 @@ contract Base is
         _deployDAO();
         clock = _deployClock(address(dao));
         escrow = new EscrowVotingPowerMock();
+        lockNFT = new MockLockNFT();
         dg = _deployEscrowIVotesAdapter(address(dao), address(clock), address(escrow));
         voter = _deployVoter(address(dao), address(clock), address(escrow), address(dg));
 
-        _mockApprovedOwner(true);
+        _mockLockNFT();
+        _mockOwner(address(this));
         // _mockPermissions();
 
         uint256 maxTime = IClock(clock).epochDuration() * CurveConstantLib.MAX_EPOCHS;
@@ -190,10 +198,34 @@ contract Base is
         assertEq(dg.slopeChanges_(_account, _end), slopeFP(_amount));
     }
 
-    function _mockApprovedOwner(bool _approved) internal {
+    function _mockLockNFT() internal {
         vm.mockCall(
             address(escrow),
-            abi.encodeWithSelector(VotingEscrow.isApprovedOrOwner.selector),
+            abi.encodeWithSelector(IVotingEscrowCore.lockNFT.selector),
+            abi.encode(address(lockNFT))
+        );
+    }
+
+    function _mockOwner(address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)"))),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockOwnerOf(uint256 _tokenId, address _owner) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("ownerOf(uint256)")), _tokenId),
+            abi.encode(_owner)
+        );
+    }
+
+    function _mockGetApproved(uint256 _tokenId, address _approved) internal {
+        vm.mockCall(
+            address(lockNFT),
+            abi.encodeWithSelector(bytes4(keccak256("getApproved(uint256)")), _tokenId),
             abi.encode(_approved)
         );
     }

--- a/test/v1_4_0/unit/delegation/Delegate.t.sol
+++ b/test/v1_4_0/unit/delegation/Delegate.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.17;
 import {Base} from "./Base.sol";
 import {DAO} from "@aragon/osx/core/dao/DAO.sol";
 import {DaoUnauthorized} from "@aragon/osx-commons-contracts/src/permission/auth/auth.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 contract TestDelegate is Base {
     function setUp() public override {
@@ -151,13 +152,34 @@ contract TestDelegate is Base {
         dg.delegate(multiIds);
     }
 
-    function testRevert_IfNotApprovedOrOwner() public {
+    function testRevert_IfNotOwner() public {
         dg.setDelegateAddress(alice);
 
-        _mockApprovedOwner(false);
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.delegate(singleId);
+    }
+
+    function testRevert_IfNotOwnerOfOneTokenButOwnerOfAnother() public {
+        dg.setDelegateAddress(alice);
+
+        // sender (address(this)) owns token 1 but not token 2
+        // token 2 is owned by alice but approved to address(this)
+        _mockOwnerOf(multiIds[0], address(this));
+        _mockOwnerOf(multiIds[1], alice);
+        _mockGetApproved(multiIds[1], address(this));
+
+        // Verify that token 2 is approved to address(this)
+        assertEq(IERC721(address(lockNFT)).getApproved(multiIds[1]), address(this));
+
+        _mockLocked(multiIds[0], 10, weekStartTs(block.timestamp));
+        _mockLocked(multiIds[1], 10, weekStartTs(block.timestamp));
+
+        // Should fail because sender doesn't own token 2, even though it's approved
+        vm.expectRevert(NotOwner.selector);
+        dg.delegate(multiIds);
     }
 
     function testRevert_IfTokenAlreadyDelegated() public {

--- a/test/v1_4_0/unit/delegation/Undelegate.t.sol
+++ b/test/v1_4_0/unit/delegation/Undelegate.t.sol
@@ -45,10 +45,11 @@ contract TestUndelegate is Base {
         dg.undelegate(getIds(1));
     }
 
-    function testRevert_IfNotApprovedOrOwner() public givenDelegatedTokens {
-        _mockApprovedOwner(false);
+    function testRevert_IfNotOwner() public givenDelegatedTokens {
+        // Mock that someone else (alice) is the owner, not this contract
+        _mockOwner(alice);
 
-        vm.expectRevert(NotApprovedOrOwner.selector);
+        vm.expectRevert(NotOwner.selector);
         dg.undelegate(multiIds);
     }
 

--- a/test/v1_4_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_4_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -109,7 +109,7 @@ contract TestVPAndCheckpoints is Base {
         dg.undelegate(singleId);
 
         // asserts latest global point.
-        assertGlobalPoint(alice, 2, 0, 0, block.timestamp);
+        assertGlobalPoint(alice, 1, 0, 0, block.timestamp);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -228,5 +228,150 @@ contract TestVPAndCheckpoints is Base {
         uint256 expectedTs = block.timestamp;
 
         assertGlobalPoint(alice, 2, biasFP(amount, maxTime), 0, expectedTs);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                  Same Timestamp Checkpoint Overwrite
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Tests that multiple delegate/undelegate operations at the same timestamp
+    ///         overwrite the same checkpoint instead of creating multiple checkpoints.
+    ///         This ensures binary search returns the correct final state.
+    function test_SameTimestampCheckpointOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        // Setup three tokens with different amounts
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // First delegation - creates checkpoint index 1
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Second delegation at same timestamp - should overwrite checkpoint index 1
+        dg.delegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+
+        // Undelegate at same timestamp - should still overwrite checkpoint index 1
+        dg.undelegate(getIds(tokenId2, tokenId3));
+        assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+
+        // Verify final state: only token1 is delegated
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(dg.getVotes(alice), expectedVP);
+
+        // Verify the checkpoint has the correct final values
+        GlobalPoint memory p = dg.pointHistory_(alice, 1);
+        assertEq(p.writtenTs, delegateTs);
+        assertEq(p.bias, biasFP(amount1, delegateTs - start));
+        assertEq(p.slope, slopeFP(amount1));
+    }
+
+    /// @notice Tests that binary search correctly returns the final checkpoint state
+    ///         when querying historical votes after checkpoint overwrite.
+    function test_BinarySearchReturnsCorrectStateAfterOverwrite() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 amount3 = 30;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 delegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+        uint256 tokenId3 = 3;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockLocked(tokenId3, amount3, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+        _mockVotingPower(tokenId3, 1);
+
+        // Multiple operations at same timestamp
+        dg.delegate(getIds(tokenId1));
+        dg.delegate(getIds(tokenId2, tokenId3));
+        dg.undelegate(getIds(tokenId2, tokenId3));
+
+        // Only checkpoint index 1 should exist with final state
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to future and create a new checkpoint to force binary search path
+        vm.warp(block.timestamp + 1 weeks);
+        dg.checkpointTransition(alice, 1);
+
+        // Now we have checkpoint index 2 at a later timestamp
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Query historical votes at the original timestamp
+        // This will use binary search since we're querying a past timestamp
+        uint256 historicalVP = dg.getPastVotes(alice, delegateTs);
+
+        // Should return the final state (only token1 delegated), not inflated value
+        uint256 expectedVP = bias(amount1, delegateTs - start);
+        assertEq(historicalVP, expectedVP);
+
+        // Verify it's NOT returning the inflated value (all three tokens)
+        uint256 inflatedVP = bias(amount1 + amount2 + amount3, delegateTs - start);
+        assertTrue(historicalVP != inflatedVP);
+    }
+
+    /// @notice Tests that checkpoints at different timestamps still create separate indices.
+    function test_DifferentTimestampsCreateSeparateCheckpoints() public {
+        dg.setDelegateAddress(alice);
+
+        uint256 amount1 = 10;
+        uint256 amount2 = 20;
+        uint256 start = weekStartTs(block.timestamp);
+        uint256 firstDelegateTs = block.timestamp;
+
+        uint256 tokenId1 = 1;
+        uint256 tokenId2 = 2;
+
+        _mockLocked(tokenId1, amount1, start);
+        _mockLocked(tokenId2, amount2, start);
+        _mockVotingPower(tokenId1, 1);
+        _mockVotingPower(tokenId2, 1);
+
+        // First delegation at timestamp T
+        dg.delegate(getIds(tokenId1));
+        assertEq(dg.latestPointIndex(alice), 1);
+
+        // Move to a different timestamp
+        vm.warp(block.timestamp + 1 weeks);
+        uint256 secondDelegateTs = block.timestamp;
+
+        // Second delegation at timestamp T+1week - should create new checkpoint
+        dg.delegate(getIds(tokenId2));
+        assertEq(dg.latestPointIndex(alice), 2);
+
+        // Verify both checkpoints exist with correct timestamps
+        GlobalPoint memory p1 = dg.pointHistory_(alice, 1);
+        GlobalPoint memory p2 = dg.pointHistory_(alice, 2);
+        assertEq(p1.writtenTs, firstDelegateTs);
+        assertEq(p2.writtenTs, secondDelegateTs);
+
+        // Query historical votes at first timestamp
+        uint256 vpAtFirst = dg.getPastVotes(alice, firstDelegateTs);
+        assertEq(vpAtFirst, bias(amount1, firstDelegateTs - start));
+
+        // Query votes at second timestamp
+        uint256 vpAtSecond = dg.getPastVotes(alice, secondDelegateTs);
+        assertEq(vpAtSecond, bias(amount1, secondDelegateTs - start) + bias(amount2, secondDelegateTs - start));
     }
 }

--- a/test/v1_4_0/unit/delegation/VPAndCheckpoints.t.sol
+++ b/test/v1_4_0/unit/delegation/VPAndCheckpoints.t.sol
@@ -261,14 +261,17 @@ contract TestVPAndCheckpoints is Base {
         // First delegation - creates checkpoint index 1
         dg.delegate(getIds(tokenId1));
         assertEq(dg.latestPointIndex(alice), 1);
+        assertEq(dg.getVotes(alice), amount1);
 
         // Second delegation at same timestamp - should overwrite checkpoint index 1
         dg.delegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 2
+        assertEq(dg.getVotes(alice), amount1 + amount2 + amount3);
 
         // Undelegate at same timestamp - should still overwrite checkpoint index 1
         dg.undelegate(getIds(tokenId2, tokenId3));
         assertEq(dg.latestPointIndex(alice), 1); // Still index 1, not 3
+        assertEq(dg.getVotes(alice), amount1);
 
         // Verify final state: only token1 is delegated
         uint256 expectedVP = bias(amount1, delegateTs - start);


### PR DESCRIPTION
Automated contract scans revealed 2 areas of the EscrowIVotesAdapter that, if misconfigured, could lead to incorrect state. This upgrade fixes the delegation checkpoint behaviour by overwriting delegation checkpoints, instead of appending them - preventing edge cases where binary search may return a stale value. It also removes approval-based delegation and undelegation flows, requiring that the msg.sender is always the owner of the tokenId, not an authorised caller. The latter path is not a useful feature in practice but could lead to incorrect state, so we have removed it. This set of transactions upgrades the contract without requiring a state change. No new state variables are introduced and no state variables are changed. Regression tests have been written to confirm this using OpenZeppelin Upgrades.